### PR TITLE
Module RunAsUser is not imported

### DIFF
--- a/startMigrate.ps1
+++ b/startMigrate.ps1
@@ -359,6 +359,10 @@ foreach($module in $modules)
         log "$module module already installed."
     }
 }
+
+# Import modules
+Import-Module RunAsUser
+
 $scriptBlock = {
     Import-Module Az.Accounts
 


### PR DESCRIPTION
Got error when trying to run the script. 
Then noticed that Invoke-AsCurrentUser (line398) is a part of RunAsUser module, but after installation for the module on line 347, the module is never imported.