### PR TITLE
Fix typo in the reboot.ps1 log file

### DIFF
--- a/reboot.ps1
+++ b/reboot.ps1
@@ -57,7 +57,7 @@ log "Reboot task disabled"
 
 # disable auto logon
 Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -Name "AutoAdminLogon" -Value 0 -Verbose
-log "Auto logon enabled."
+log "Auto logon disabled."
 
 # set new wallpaper
 $wallpaper = (Get-ChildItem -Path $config.localPath -Filter "*.jpg" -Recurse).FullName
@@ -536,7 +536,6 @@ else
 
 
 
-
 # enable logon provider
 reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Authentication\Credential Providers\{60b78e88-ead8-445c-9cfd-0b87f74ea6cd}" /v "Disabled" /t REG_DWORD /d 0 /f | Out-Host
 log "Enabled logon provider."
@@ -558,5 +557,3 @@ log "Lock screen caption set."
 log "Reboot.ps1 complete"
 Stop-Transcript
 shutdown -r -t 00
-
-


### PR DESCRIPTION
Fixes #9

Update the log message in `reboot.ps1` to correct a typo.

* Change the log message on line 60 from "Auto logon enabled." to "Auto logon disabled."

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/stevecapacity/intune-device-migration-8/issues/9?shareId=XXXX-XXXX-XXXX-XXXX).