### PR TITLE
Correct Typo in Az.Accounts fix that is causing module installs to fail.

### DIFF
--- a/startMigrate.ps1
+++ b/startMigrate.ps1
@@ -369,7 +369,7 @@ foreach($module in $modules)
             log "Uninstalling newer version of $($module)..."
             Uninstall-Module -Name $Module -AllVersions -Force
             log "Installing $($module) version 4.2.0..."
-            Install-Module -Name $modules -RequiredVersion "4.2.0" -Force
+            Install-Module -Name $module -RequiredVersion "4.2.0" -Force
             log "Az.Accounts module version 4.2.0 installed successfully."
         }
         else


### PR DESCRIPTION
Corrected typo that is causing module installs to fail of Az.Accounts

TerminatingError(Install-Module): "The RequiredVersion, MinimumVersion, MaximumVersion, AllVersions or AllowPrerelease parameters are allowed only when you specify a single name as the value of the Name parameter, without any wildcard characters."

$modules is the array, module is the individual item. 
